### PR TITLE
support to log the golangsdk by HW_DEBUG env

### DIFF
--- a/huaweicloud/access_config.go
+++ b/huaweicloud/access_config.go
@@ -102,10 +102,16 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		TLSClientConfig: tlsConfig,
 	}
 
+	var enableLog bool
+	debugEnv := os.Getenv("HW_DEBUG")
+	if debugEnv != "" && debugEnv != "0" {
+		enableLog = true
+	}
+
 	client.HTTPClient = http.Client{
 		Transport: &LogRoundTripper{
 			Rt:    transport,
-			Debug: os.Getenv("PACKER_LOG") != "" && os.Getenv("PACKER_LOG") != "0",
+			Debug: enableLog,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if client.AKSKAuthOptions.AccessKey != "" {

--- a/huaweicloud/http_log.go
+++ b/huaweicloud/http_log.go
@@ -127,13 +127,21 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 	}
 
 	// Ignore the catalog
-	if _, ok := data["catalog"]; ok {
-		return ""
+	if _, ok := data["catalog"].([]interface{}); ok {
+		return "{ **skipped** }"
 	}
 	if v, ok := data["token"].(map[string]interface{}); ok {
 		if _, ok := v["catalog"]; ok {
-			return ""
+			return "{ **skipped** }"
 		}
+	}
+
+	// Ignore the services and endpoints
+	if _, ok := data["services"].([]interface{}); ok {
+		return "{ **skipped** }"
+	}
+	if _, ok := data["endpoints"].([]interface{}); ok {
+		return "{ **skipped** }"
 	}
 
 	pretty, err := json.MarshalIndent(data, "", "  ")


### PR DESCRIPTION
we can export the `HW_DEBUG` enviroment variable, then the API request
and response will be logged into `PACKER_LOG_PATH`

Signed-off-by: ShiChangkuo <shichangkuo90@gmail.com>