### PR TITLE
Update packer-plugin-sdk to use version 0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/hcl/v2 v2.8.0
-	github.com/hashicorp/packer-plugin-sdk v0.0.8
+	github.com/hashicorp/packer-plugin-sdk v0.1.0
 	github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517
 	github.com/mitchellh/mapstructure v1.4.0
 	github.com/unknwon/com v1.0.1


### PR DESCRIPTION
A recent update in the packer-plugin-sdk was a breaking change in Packer's internal marshalling for communicating with plugins : https://github.com/hashicorp/packer-plugin-sdk/pull/31

It could be that this project is not impacted, but updating to v0.1 will make sure it's not the case.
I didn't update the `go.sum` file, this will happen automatically next time you run `go ...` in the project folder.